### PR TITLE
Fix ImportError for AES Cipher in Crypto.Cipher

### DIFF
--- a/py_arkose_generator/crypt.py
+++ b/py_arkose_generator/crypt.py
@@ -3,8 +3,10 @@ import hashlib
 import json
 import random
 
-from Crypto.Cipher import AES
-
+try:
+    from Crypto.Cipher import AES
+except ImportError:
+    from Cryptodome.Cipher import AES
 
 def pad(data):
     # Convert the string to bytes and calculate the number of bytes to pad


### PR DESCRIPTION
Hello,

I've encountered an issue where the current implementation using Crypto.Cipher does not work with my Python version. To address this, I propose a backward-compatible change that attempts to import AES from Crypto.Cipher and falls back to Cryptodome.Cipher if the former is unavailable.

Here is the change I made:
```python
try:
    from Crypto.Cipher import AES
except ImportError:
    from Cryptodome.Cipher import AES
```

This modification ensures compatibility for environments where Crypto.Cipher is not supported while maintaining functionality for those where it is. I've tested this change in my environment, and it resolves the issue without affecting the existing behavior.